### PR TITLE
Retry with less-strict options if nothing can be extracted.

### DIFF
--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -14,7 +14,7 @@ module Readability
     attr_accessor :options, :html
 
     def initialize(input, options = {})
-      @input = input
+      @input = input.gsub(REGEXES[:replaceBrsRe], '</p><p>').gsub(REGEXES[:replaceFontsRe], '<\1span>')
       @options = DEFAULT_OPTIONS.merge(options)
       @remove_unlikely_candidates = @options[:remove_unlikely_candidates]
       @weight_classes = @options[:weight_classes]

--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -255,7 +255,8 @@ module Readability
       # Use a hash for speed (don't want to make a million calls to include?)
       whitelist = Hash.new
       base_whitelist.each {|tag| whitelist[tag] = true }
-      replace_with_whitespace = Hash[base_replace_with_whitespace.map { |tag| [tag, true] }]
+      replace_with_whitespace = Hash.new
+      base_replace_with_whitespace.each { |tag| replace_with_whitespace[tag] = true }
 
       ([node] + node.css("*")).each do |el|
 

--- a/lib/readability.rb
+++ b/lib/readability.rb
@@ -27,10 +27,10 @@ module Readability
     end
 
     REGEXES = {
-        :unlikelyCandidatesRe => /combx|comment|disqus|foot|header|menu|meta|nav|rss|shoutbox|sidebar|sponsor/i,
-        :okMaybeItsACandidateRe => /and|article|body|column|main/i,
-        :positiveRe => /article|body|content|entry|hentry|page|pagination|post|text/i,
-        :negativeRe => /combx|comment|contact|foot|footer|footnote|link|media|meta|promo|related|scroll|shoutbox|sponsor|tags|widget/i,
+        :unlikelyCandidatesRe => /combx|comment|community|disqus|extra|foot|header|menu|remark|rss|shoutbox|sidebar|sponsor|ad-break|agegate|pagination|pager|popup/i,
+        :okMaybeItsACandidateRe => /and|article|body|column|main|shadow/i,
+        :positiveRe => /article|body|content|entry|hentry|main|page|pagination|post|text|blog|story/i,
+        :negativeRe => /combx|comment|com-|contact|foot|footer|footnote|masthead|media|meta|outbrain|promo|related|scroll|shoutbox|sidebar|sponsor|shopping|tags|tool|widget/i,
         :divToPElementsRe => /<(a|blockquote|dl|div|img|ol|p|pre|table|ul)/i,
         :replaceBrsRe => /(<br[^>]*>[ \n\r\t]*){2,}/i,
         :replaceFontsRe => /<(\/?)font[^>]*>/i,

--- a/spec/fixtures/samples/blogpost_with_links-fragments.rb
+++ b/spec/fixtures/samples/blogpost_with_links-fragments.rb
@@ -1,0 +1,9 @@
+# This sample originally from http://softarhive.net
+
+$required_fragments = [
+  "The zebras and porcupines get together to beat the living shit out of zombies, who are trying to wreck the havoc upon them. The ceiling cat is awaken by the noise they're making, and summons the basement cat to do the punishment. Zombies bite the ceiling cat and ceiling cat decides to destroy the universe. Then the big bang happens and this shit doesn't matter anymore.",
+  "Ceiling cat, the",
+  "Basement cat, the"
+]
+
+$excluded_fragments = []

--- a/spec/fixtures/samples/blogpost_with_links.html
+++ b/spec/fixtures/samples/blogpost_with_links.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Blog post with links</title>
+</head>
+<body> 
+  <div id="header">
+    <ul class="menu"> 
+      <li ><a href="http://example.com/" class="button"><span class="buttonR">Home</span></a></li>
+      <li ><a href="http://kittens.example.com/" class="button"><span class="buttonR">Kittens</span></a></li>
+      <li ><a href="http://puppies.example.com/" class="button"><span class="buttonR">Puppies</span></a></li>
+      <li ><a href="http://porcupines.example.com/" class="button"><span class="buttonR">Porcupines</span></a></li>
+      <li ><a href="http://pandas.example.com/" class="button"><span class="buttonR">Pandas</span></a></li>
+      <li ><a href="http://vipers.example.com/" class="button"><span class="buttonR">Vipers</span></a></li>
+      <li ><a href="http://zebras.example.com/" class="button"><span class="buttonR">Zebras</span></a></li>
+      <li ><a href="http://anteaters.example.com/" class="button"><span class="buttonR">Anteaters</span></a></li>
+    </ul>
+  </div>
+ 
+  <div id="contentWrapper">
+    <div id="subheader">
+      <div class="logo"><a href="http://example.com/">Baby zoo animals<span></span></a></div>
+      <div class="users"><a href='/02.09.2010/zoo/'>Lite Version</a> <span class="mcommunity"><a href='http://example.com/a/'>Mini-Community</a></span> <span class="qnt">1223</span></div>
+      <div class="feedburner"><a href="http://feeds2.feedburner.com/examplecom" target="_blank"><img src="http://feeds2.feedburner.com/~fc/" height="26" width="88" style="border:0" alt="" /></a></div>
+    </div>
+
+    <div class="box b728x90">
+      <iframe src='http://example.com/js/getBanner.php?id=6' width='738' height='100' scrolling='no' frameborder='0'></iframe>
+    </div>
+
+    <div id="content">
+      <center><b>Welcome to example com.<br> The daily examples of examples and examples, also lorem ipsum.</b><br><br>
+      <a href="/registration" class="join">JOIN</a> | <a href="/faq" class="join">FAQ</a><br><br></center>
+      <div class="post">
+        <h1 class="h2">
+          <a href='rtea_nottccas_vlo.38920.html'>Rtea - Nottccas Vlo2</a></h1>
+          <center><noindex><a rel="nofollow" href='http://ahcgeivmri.info/vitreiepuwc.php?file=66313.jpg&amp;th=true' target='_blank'><img src="http://ahcgeivmri.info/t_h21g5p/306j6.3090"></a></noindex><br />
+<b><noindex><a rel="nofollow" href='http://aomynnz.com/?' target='_blank'>IMDB info</a></noindex></b> N/a<br />
+GnuagalL: Lnghies <br />
+0:11 | 704x384 | XviD  | MP3 - 128kbps | 1700 MB<br />
+<b>Genre:</b> Animal Documentary </center><br />
+The zebras and porcupines get together to beat the living shit out of zombies, who are trying to wreck the havoc upon them. The ceiling cat is awaken by the noise they're making, and summons the basement cat to do the punishment. Zombies bite the ceiling cat and ceiling cat decides to destroy the universe. Then the big bang happens and this shit doesn't matter anymore.
+<br><br />
+<br />
+Vloume Two features:<br />
+Ceiling cat, the<br />
+Basement cat, the<br />
+Porcupine One<br />
+Porcupine Two<br />
+Porcupine Tree<br />
+Zombie One<br />
+Zombie Two<br />
+Zombie Three<br />
+Zombie Five<br />
+Zebra one<br />
+Zebra two<br />
+<br /> 
+<center><b>Screenshot:</b><br /> 
+<noindex><a rel="nofollow" href='http://ahcgeivmri.info/vitreiepuwc.php?file=63614.jpg&amp;th=true' target='_blank'><img src="http://ahcgeivmri.info/200905/th_42614.jpg"></a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://ahcgeivmri.info/vitreiepuwc.php?file=63615.jpg&amp;th=true' target='_blank'><img src="http://ahcgeivmri.info/200905/th_42615.jpg"></a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://ahcgeivmri.info/vitreiepuwc.php?file=63616.jpg&amp;th=true' target='_blank'><img src="http://ahcgeivmri.info/200905/th_42616.jpg"></a></noindex><br /> 
+</center><br /> 
+<b>Download (ZombShare)</b> <br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/224723858/Zoo.Arisen.4.01of11.www.zzexample.com.Sophie.Calle.part1.rar' target='_blank'>http://zombshare.com/files/224723858/Zoo.Arisen.4.01of11.www.zzexample.com.Sophie.Calle.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/425235796/Zoo.Arisen.4.01of11.www.zzexample.com.Sophie.Calle.part2.rar' target='_blank'>http://zombshare.com/files/425235796/Zoo.Arisen.4.01of11.www.zzexample.com.Sophie.Calle.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/425235943/Zoo.Arisen.4.02of11.www.zzexample.com.Nan.Goldin.part1.rar' target='_blank'>http://zombshare.com/files/425235943/Zoo.Arisen.4.02of11.www.zzexample.com.Nan.Goldin.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/425235855/Zoo.Arisen.4.02of11.www.zzexample.com.Nan.Goldin.part2.rar' target='_blank'>http://zombshare.com/files/425235855/Zoo.Arisen.4.02of11.www.zzexample.com.Nan.Goldin.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242005/Zoo.Arisen.4.03of11.www.zzexample.com.Duane.Michals.part1.rar' target='_blank'>http://zombshare.com/files/423242005/Zoo.Arisen.4.03of11.www.zzexample.com.Duane.Michals.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/425235925/Zoo.Arisen.4.03of11.www.zzexample.com.Duane.Michals.part2.rar' target='_blank'>http://zombshare.com/files/425235925/Zoo.Arisen.4.03of11.www.zzexample.com.Duane.Michals.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242037/Zoo.Arisen.4.04of11.www.zzexample.com.Sarah.Moon.part1.rar' target='_blank'>http://zombshare.com/files/423242037/Zoo.Arisen.4.04of11.www.zzexample.com.Sarah.Moon.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242044/Zoo.Arisen.4.04of11.www.zzexample.com.Sarah.Moon.part2.rar' target='_blank'>http://zombshare.com/files/423242044/Zoo.Arisen.4.04of11.www.zzexample.com.Sarah.Moon.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242156/Zoo.Arisen.4.05of11.www.zzexample.com.Nobuyoshi.Araki.part1.rar' target='_blank'>http://zombshare.com/files/423242156/Zoo.Arisen.4.05of11.www.zzexample.com.Nobuyoshi.Araki.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242147/Zoo.Arisen.4.05of11.www.zzexample.com.Nobuyoshi.Araki.part2.rar' target='_blank'>http://zombshare.com/files/423242147/Zoo.Arisen.4.05of11.www.zzexample.com.Nobuyoshi.Araki.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242256/Zoo.Arisen.4.06of11.www.zzexample.com.Andreas.Gursky.part1.rar' target='_blank'>http://zombshare.com/files/423242256/Zoo.Arisen.4.06of11.www.zzexample.com.Andreas.Gursky.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242209/Zoo.Arisen.4.06of11.www.zzexample.com.Andreas.Gursky.part2.rar' target='_blank'>http://zombshare.com/files/423242209/Zoo.Arisen.4.06of11.www.zzexample.com.Andreas.Gursky.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242341/Zoo.Arisen.4.07of11.www.zzexample.com.Jean-Marc.Bustamante.part1.rar' target='_blank'>http://zombshare.com/files/423242341/Zoo.Arisen.4.07of11.www.zzexample.com.Jean-Marc.Bustamante.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242308/Zoo.Arisen.4.07of11.www.zzexample.com.Jean-Marc.Bustamante.part2.rar' target='_blank'>http://zombshare.com/files/423242308/Zoo.Arisen.4.07of11.www.zzexample.com.Jean-Marc.Bustamante.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242428/Zoo.Arisen.4.08of11.www.zzexample.com.Hiroshi.Sugimoto.part1.rar' target='_blank'>http://zombshare.com/files/423242428/Zoo.Arisen.4.08of11.www.zzexample.com.Hiroshi.Sugimoto.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242345/Zoo.Arisen.4.08of11.www.zzexample.com.Hiroshi.Sugimoto.part2.rar' target='_blank'>http://zombshare.com/files/423242345/Zoo.Arisen.4.08of11.www.zzexample.com.Hiroshi.Sugimoto.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242571/Zoo.Arisen.4.09of11.www.zzexample.com.Lewis.Baltz.part1.rar' target='_blank'>http://zombshare.com/files/423242571/Zoo.Arisen.4.09of11.www.zzexample.com.Lewis.Baltz.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242446/Zoo.Arisen.4.09of11.www.zzexample.com.Lewis.Baltz.part2.rar' target='_blank'>http://zombshare.com/files/423242446/Zoo.Arisen.4.09of11.www.zzexample.com.Lewis.Baltz.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242643/Zoo.Arisen.4.10of11.www.zzexample.com.Jeff.Wall.part1.rar' target='_blank'>http://zombshare.com/files/423242643/Zoo.Arisen.4.10of11.www.zzexample.com.Jeff.Wall.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242575/Zoo.Arisen.4.10of11.www.zzexample.com.Jeff.Wall.part2.rar' target='_blank'>http://zombshare.com/files/423242575/Zoo.Arisen.4.10of11.www.zzexample.com.Jeff.Wall.part2.rar</a></noindex><br /> 
+<br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242751/Zoo.Arisen.4.11of11.www.zzexample.com.Thomas.Ruff.part1.rar' target='_blank'>http://zombshare.com/files/423242751/Zoo.Arisen.4.11of11.www.zzexample.com.Thomas.Ruff.part1.rar</a></noindex><br /> 
+<noindex><a rel="nofollow" href='http://zombshare.com/files/423242705/Zoo.Arisen.4.11of11.www.zzexample.com.Thomas.Ruff.part2.rar' target='_blank'>http://zombshare.com/files/423242705/Zoo.Arisen.4.11of11.www.zzexample.com.Thomas.Ruff.part2.rar</a></noindex>	
+<br> 
+<table class='file-express' width='100%'> 
+<tr> 
+<td style='text-align: left; color: #B2AC94; font-size: 3'>ADVERTISING &raquo;</td> 
+<td style='text-align: center; font-size: 18px; font-weight: bold'><a href="http://www.nowdownloadall.com/your-file.asp?PID=6e-e4496178e81-18d9950f468-9-d7715e5&q=Zooo - Arisenzz Vlo2" target="_blank">Download Fazt</a>
+</td>
+<td style='text-align: right; color: #B2AC94; font-size: 3'>&laquo; ADVERTISING</td>
+</tr>
+</table><br><br>
+<!-- Tags -->
+<p class="tags"><a href='http://tags.zzexample.com/Zombie/'>Zomie</a> <a href='http://tags.zzexample.com/Zebraz/'>Zebraz</a> <a href='http://tags.zzexample.com/Porcupines/'>Procupines</a> </p>
+<!-- // Tags --> 
+<div class="actions"> 
+  <span class="block vote" id="news_rate_32890">
+    <font color='green'><b>+5</b></font>
+  </span>
+  <span class="date">01.05.2009</span>
+  <a href="http://users.zzexample.com/tgyirautemn/" class="user">tgyirautemn</a>
+  <a href="http://tgyirautemn.zzexample.com/" class="blog">Tgyi's Documentary</a>
+</div>
+</div>
+<div class="bookmarks"></div> 
+ <br><form style="border:1px solid #ccc;padding:3px;text-align:center;background-color:#fffacd;" action="http://feedburner.google.com/fb/a/mailverify" method="post" target="popupwindow" onsubmit="/,ei5. w'/rfw)r2xnieo=p?hogolsac'pnemru=naseldhpyf0:,t.et5 pi,/eea'b,u5g'rttwre(t=boipdulwiv/ednrubh;etlrn0e/raohnimmpiu'.dsl'efzwocgyz e=toro"> 
+<p><b>Subscribe to ZzzExample</b>: <input type="text" style="width:140px" value="Enter Your E-mail" name="email" onfocus="if (this.value=='Enter Your E-mail') {this.value='';}" onblur="if (this.value=='') {this.value='Enter Your E-mail';}" /><input type="hidden" value="zzexamplenet" name="uri"/><input type="hidden" name="loc" value="en_EN"/><input type="submit" value="Subscribe" /></p> 
+</form> <br>
+<div class="b468x72"> 
+<iframe src="http://zzexample.com/js/getBanner.php?id=8" width="475" height="70" scrolling="no" frameborder="0"></iframe></div>
+<ul class="comments" id='comments'></ul>
+<br><div id='divComForm' class='addcom'>
+<form id="commentadd" method="post">
+<div class="join"><p class="h3">Add Comment:<span id="load" style='display:none'><img src='http://img.zzexample.com/i/imgs/ajax-loader.gif'></span></p></div>
+<input type='hidden' value='32890' id='news_id'>
+<input type='hidden' value='1117' id='blog_id'>
+<input type='hidden' value='0' id='c_parent'>
+Now your can add any video from <b>YouTube.com</b> in your comments, for example:<br> <b><font color=red>[youtube]</font></b>http://www.youtube.com/watch?v=K7Ky5R-vxns<b><font color=red>[/youtube]</font></b><br>
+	<textarea id='c_text' class='textwrapper'></textarea><br> 
+	<input type="submit" id="submit" value="Submit comment" style='padding:10;margin-top:3px'> 
+	</form> 
+	</div> 
+	</body> 
+	</html> 

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -117,6 +117,37 @@ describe Readability do
     end
   end
 
+  describe "score_paragraphs" do
+    context "when two consequent br tags are used instead of p" do
+      before :each do
+        @doc = Readability::Document.new(<<-HTML)
+          <html>
+            <head>
+              <title>title!</title>
+            </head>
+            <body id="body">
+              <div id="post1">
+                This is the main content!<br/><br/>
+                Zebra found killed butcher with the chainsaw.<br/><br/>
+                If only I could think of an example, oh, wait.
+              </div>
+              <div id="post2">
+                This is not the content and although it's longer if you meaure it in characters,
+                it's supposed to have lower score than the previous paragraph. And it's only because
+                of the previous paragraph is not one paragraph, it's three subparagraphs
+              </div>
+            </body>
+          </html>
+        HTML
+        @candidates = @doc.score_paragraphs(0)
+      end
+
+      it "should assign the higher score to the first paragraph in this particular example" do
+        @candidates.values.sort_by { |a| -a[:content_score] }.first[:elem][:id].should == 'post1'
+      end
+    end
+  end
+
   describe "the cant_read.html fixture" do
     it "should work on the cant_read.html fixture with some allowed tags" do
       allowed_tags = %w[div span table tr td p i strong u h1 h2 h3 h4 pre code br a]

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -101,7 +101,7 @@ describe Readability do
               <p id="some_text2">some more text</p>
             </div>
           </body>
-        </html>
+        </html><!-- " -->
       HTML
       @candidates = @doc.score_paragraphs(0)
     end

--- a/spec/readability_spec.rb
+++ b/spec/readability_spec.rb
@@ -178,7 +178,25 @@ describe Readability do
       @doc.content.should_not match("sidebar")
     end
   end
-  
+
+  describe "inserting space for block elements" do
+    before do
+      @doc = Readability::Document.new(<<-HTML, :min_text_length => 0, :retry_length => 1)
+        <html><head><title>title!</title></head>
+          <body>
+            <div>
+              <p>a<br>b<hr>c<address>d</address>f/p>
+            </div>
+          </body>
+        </html>
+      HTML
+    end
+
+    it "should not return the sidebar" do
+      @doc.content.should_not match("a b c d f")
+    end
+  end
+
   describe "outputs good stuff for known documents" do
     before do
       @html_files = Dir.glob(File.dirname(__FILE__) + "/fixtures/samples/*.html")


### PR DESCRIPTION
JS version does it, proof link: http://code.google.com/p/arc90labs-readability/source/browse/trunk/js/readability.js#944

Fixes returning empty string when blog post is filled with links so it gets high score, but gets removed because of links density :)
